### PR TITLE
fix(ui): Preloads overflow clipping and CodeBreak button placement

### DIFF
--- a/.changeset/fix-ui-layout-polish.md
+++ b/.changeset/fix-ui-layout-polish.md
@@ -1,0 +1,8 @@
+---
+'@qwik.dev/devtools': patch
+---
+
+fix(ui): Preloads overflow clipping and CodeBreak button placement
+
+- Preloads panel: outer `overflow-hidden` clipped stat cards and prevented scroll when content exceeded the panel height. Switched to `overflow-auto` with `min-h-full` on the column stack so content scrolls on narrow or short panels.
+- CodeBreak StateParser: content container was missing the `flex` class, so the textarea pushed the `Parse State` button outside the card into the next grid row, overlapping the `Parsed State` header. Moved the button into the card header next to the title — robust across panel widths and cleaner UX.

--- a/packages/ui/src/features/CodeBreak/StateParser.tsx
+++ b/packages/ui/src/features/CodeBreak/StateParser.tsx
@@ -117,31 +117,31 @@ export const StateParser = component$(() => {
   return (
     <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
       <div class="border-glass-border bg-card-item-bg flex h-[60vh] min-h-0 flex-col rounded-xl border">
-        <div class="border-glass-border flex items-center justify-between border-b p-3">
-          <div class="text-sm font-medium">Input State</div>
-          {parsingTime.value !== null && (
-            <span class="border-glass-border text-muted-foreground rounded-full border px-2 py-0.5 text-xs">
-              {parsingTime.value}ms
-            </span>
-          )}
+        <div class="border-glass-border flex items-center justify-between gap-3 border-b p-3">
+          <div class="flex items-center gap-3">
+            <div class="text-sm font-medium">Input State</div>
+            {parsingTime.value !== null && (
+              <span class="border-glass-border text-muted-foreground rounded-full border px-2 py-0.5 text-xs">
+                {parsingTime.value}ms
+              </span>
+            )}
+          </div>
+          <button
+            onClick$={onParseState$}
+            class="bg-accent rounded-md px-3 py-1.5 text-sm text-white hover:opacity-90"
+          >
+            Parse State
+          </button>
         </div>
-        <div class="min-h-0 flex-1 flex-col space-y-3 p-3">
+        <div class="flex min-h-0 flex-1 flex-col p-3">
           <textarea
             value={inputState.value}
             onInput$={(e: InputEvent, t: HTMLTextAreaElement) =>
               (inputState.value = (t as HTMLTextAreaElement).value)
             }
             placeholder="Paste Qwik state and click to parse/format."
-            class="border-glass-border bg-card-item-bg text-foreground h-full min-h-0 w-full flex-1 resize-none rounded-md border p-3 font-mono text-sm placeholder:text-muted-foreground"
+            class="border-glass-border bg-card-item-bg text-foreground min-h-0 w-full flex-1 resize-none rounded-md border p-3 font-mono text-sm placeholder:text-muted-foreground"
           />
-          <div class="flex items-center gap-3">
-            <button
-              onClick$={onParseState$}
-              class="bg-accent rounded-md px-3 py-1.5 text-sm text-white hover:opacity-90"
-            >
-              Parse State
-            </button>
-          </div>
         </div>
       </div>
 

--- a/packages/ui/src/features/Preloads/Preloads.tsx
+++ b/packages/ui/src/features/Preloads/Preloads.tsx
@@ -102,8 +102,8 @@ export const Preloads = component$(() => {
   });
 
   return (
-    <div class="h-full w-full flex-1 overflow-hidden">
-      <div class="flex h-full min-h-0 flex-col gap-4">
+    <div class="h-full w-full flex-1 overflow-auto">
+      <div class="flex min-h-full flex-col gap-4">
         <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-5">
           <StatCard
             label="Visible QRLs"


### PR DESCRIPTION
## Summary

Two UI polish fixes spotted while testing the browser extension and the in-app overlay on the Preloads and Code Break panels.

### Preloads — outer container clipped content

The Preloads panel root used `overflow-hidden` on an `h-full` flex container. When the stat-cards grid and filter header took up most of the available vertical space (common in narrower devtools panels), the table below was pushed out of view with no way to scroll. Horizontally, the stat cards were also clipped on narrower widths because of the same outer `overflow-hidden`.

Switched the outer container to `overflow-auto` and replaced `h-full min-h-0` on the column stack with `min-h-full` so the content can grow past the viewport and scroll naturally. The inner table keeps its own horizontal scroll wrapper for the `min-w-[1080px]` table, so the sticky header behaviour is preserved.

**Diff:** `packages/ui/src/features/Preloads/Preloads.tsx`

### CodeBreak (StateParser) — Parse State button overlapped the next card

The content container inside the Input State card had the classes `min-h-0 flex-1 flex-col space-y-3 p-3` — note the missing `flex`. Without `flex`, `flex-col` is a no-op and the textarea's `h-full` expanded to the full card height, pushing the `Parse State` button outside the card. On the mobile-stacked layout (single column), that button then landed directly on top of the `Parsed State` card's header, making it visually overlap and hard to click.

Rather than reintroducing the missing `flex` and hoping the stack stays balanced at all widths, moved the `Parse State` button into the Input State card header alongside the title. More robust across panel widths, easier to reach, and consistent with the rest of the UI where per-card actions live in the header.

**Diff:** `packages/ui/src/features/CodeBreak/StateParser.tsx`

## Testing

- Playground overlay (`pnpm --filter playground dev`, then open `http://localhost:5174/`): both panels render correctly at narrow and wide widths; Preloads scrolls, Parse State button visible and clickable in the header.
- Chrome extension (`pnpm --filter @devtools/ui build && pnpm --filter @devtools/browser-extension build`, reload in `chrome://extensions`): Preloads panel no longer clips; Code Break tab button lives in the header, no overlap with the Parsed State card.

## Notes

- Pure UI/CSS change, no public API or behavioural surface affected.
- Tests unchanged (UI package: 42 passing; extension: 8 passing).
- Also reminded me that `@devtools/ui` ships a pre-built `lib/`, so extension rebuilds need the UI build step first (`pnpm --filter @devtools/ui build`) — unrelated to this PR but worth flagging for future extension work.